### PR TITLE
update to support no iso-8859-15 language

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -259,7 +259,10 @@ class soundplay:
                         else:
                             txtfile.write(data.arg.encode('ISO-8859-15'))
                     except UnicodeEncodeError:
-                        txtfile.write(data.arg.encode('UTF-8'))
+                        if hasattr(data.arg, 'decode'):
+                            txtfile.write(data.arg)
+                        else:
+                            txtfile.write(data.arg.encode('UTF-8'))
                     txtfile.flush()
                     os.system("text2wave -eval '("+voice+")' "+txtfilename+" -o "+wavfilename)
                     try:

--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -254,11 +254,12 @@ class soundplay:
                 voice = data.arg2
                 try:
                     try:
-                        txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                        if hasattr(data.arg, 'decode'):
+                            txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                        else:
+                            txtfile.write(data.arg.encode('ISO-8859-15'))
                     except UnicodeEncodeError:
-                        txtfile.write(data.arg)
-                    except AttributeError:
-                        txtfile.write(data.arg.encode('ISO-8859-15'))
+                        txtfile.write(data.arg.encode('UTF-8'))
                     txtfile.flush()
                     os.system("text2wave -eval '("+voice+")' "+txtfilename+" -o "+wavfilename)
                     try:


### PR DESCRIPTION
update https://github.com/ros-drivers/audio_common/pull/154 to support for non iso-8859-15 language
I checked with our japanese speaking robots.

- python2
 - [x] iso-8859-15 language
 - [x] non iso-8859-15 language
- python3
 - [x] iso-8859-15 language
 - [x] non iso-8859-15 language